### PR TITLE
leave undefined values in place

### DIFF
--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -24,6 +24,7 @@ function _swap(parameter, settings) {
 
     // get the setting value for this parameter
     value = get(settings, parameter)
+
     // console.info(`Param ${parameter} value: ${JSON.stringify(value)}`);
     // TODO: If necessary, call transform methods
     // if(transformFunction !== undefined && transformFunction !== null) {
@@ -52,7 +53,7 @@ export default function adlib(template, settings) {
             let path = entry.replace(/{|}/g, '');
             return {
               key: entry,
-              value: _swap(path, settings)
+              value: _swap(path, settings) || entry
             };
           });
           values.forEach((v) => {

--- a/test/adlib.spec.js
+++ b/test/adlib.spec.js
@@ -67,6 +67,20 @@ describe('adlib ::', () => {
       expect(result.value).to.equal('The value is red and red');
     })
 
+    it('should leave undefined instances within a larger string', () => {
+      let template = {
+        value: 'The value is {{thing.novalue}} and {{thing.value}}'
+      };
+      let settings = {
+        thing: {
+          value: 'red'
+        }
+      };
+      let result = adlib(template, settings);
+
+      expect(result.value).to.equal('The value is {{thing.novalue}} and red');
+    })
+
     it('should replace multiple values in a string', () => {
       let template = {
         value: 'The {{thing.animal}} was {{thing.color}} but still a {{thing.animal}}'


### PR DESCRIPTION
Allows the following:
- assuming: 
```
{
  thing: {
       value: 'red'
   }
}
```
- `'The value is {{thing.novalue}} and {{thing.value}}'` --> `'The value is {{thing.novalue}} and red'`