### PR TITLE
Add entry point and lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+import adlib from "./lib/adlib"
+export default adlib

--- a/profiles/base.js
+++ b/profiles/base.js
@@ -5,13 +5,13 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 const pkg = require('../package.json');
 const copyright = `/**
 * ${pkg.name} - v${pkg.version} - ${new Date().toString()}
-* Copyright (c) ${new Date().getFullYear()} Dave Bouwman / Esri
+* Copyright (c) ${new Date().getFullYear()} ${pkg.author.name} / Esri
 * ${pkg.license}
 */`;
 
 export default {
-  entry: 'lib/adlib.js',
-  moduleName: 'adlib',
+  entry: `lib/${pkg.name}.js`,
+  moduleName: pkg.name,
   format: 'umd',
   plugins: [
     nodeResolve({ main: true }),


### PR DESCRIPTION
@dbouwman These changes allowed me to `import 'adlib'` into another project.

However, I couldn't verify them working within the project b/c it didn't build for me with simple `npm run build`