### PR TITLE
allow more chars in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 2.2.4
+### Fixed
+- allow more chars in templates - now allows for `{{{foo.bar||http://s.com/123/_(foo)_/ウォ/🏹.?b=c&d=f}}}`
 
 # 2.2.3
 ### Fixed

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -82,7 +82,8 @@ export default function adlib(template, settings, transforms = null) {
     var settingsValue;
     var replaceValue = false;
 
-    var handlebars = /{{[\w\.\:||&\/?=]*?}}/g;
+    var handlebars = /{{[\w].*?}}/g;
+
     let hbsEntries = templateValue.match(handlebars);
 
     if (hbsEntries && hbsEntries.length) {

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -685,6 +685,51 @@ test('Adlib::Hierarchies:: last choice can be a static url', (t) => {
   t.end();
 })
 
+test('Adlib::Hierarchies:: last choice can be a static url with odd chars', (t) => {
+  let template = {
+    msg: 'Site is at {{obj.mainUrl||obj.otherUrl||https://foo.bar/path/deep/_(wat)_/123?o=p&e=n}}'
+  }
+
+  var settings = {}
+
+  let result = adlib(template, settings)
+
+  t.plan(1);
+  t.equal(result.msg, 'Site is at https://foo.bar/path/deep/_(wat)_/123?o=p&e=n');
+  t.end();
+})
+
+
+
+test('Adlib::Hierarchies:: last choice can be a static url with unicode', (t) => {
+  let template = {
+    msg: 'Site is at {{obj.mainUrl||obj.otherUrl||http://example.com/スター・ウォーズ×マンガ/}}'
+  }
+
+  var settings = {}
+
+  let result = adlib(template, settings)
+
+  t.plan(1);
+  t.equal(result.msg, 'Site is at http://example.com/スター・ウォーズ×マンガ/');
+  t.end();
+})
+
+test('Adlib::Hierarchies:: last choice can be a static url with emoji', (t) => {
+  let template = {
+    msg: 'Site is at {{obj.mainUrl||obj.otherUrl||🏹.to/id7g}}'
+  }
+
+  var settings = {}
+
+  let result = adlib(template, settings)
+
+  t.plan(1);
+  t.equal(result.msg, 'Site is at 🏹.to/id7g');
+  t.end();
+})
+
+
 test('Adlib::Hierarchies:: last choice can be a int', (t) => {
   let template = {
     msg: 'Luke is {{obj.happy||obj.sad||68}}',


### PR DESCRIPTION
Previous hbs regex was too strict - this allows a much wider range of chars in the string... allowing for stuff like `http://s.com/123/_(foo)_/ウォ/🏹.?b=c&d=f`