### PR TITLE
add function to list dependencies of a template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- listDependencies function to list all variables in a template
+
 # 2.2.5
 ### Changed
 - upgraded build/test dependencies to eliminate possible vulnerabilities with `growl < 1.10.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
-- listDependencies function to list all variables in a template
+- adlib.listDependencies function to list all variables in a template
 
 # 2.2.5
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To get a feel for how adlib works, check out this [Live Demo](https://arcgis.git
 
 ## API
 ```js
-import adlib, { listDependencies } from 'adlib'
+import adlib from 'adlib'
 adlib(template, settings) // renders an adlib template
-listDependencies(template) // list all dependecies of an adlib template
+adlib.listDependencies(template) // list all dependecies of an adlib template
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ The [ArcGIS Hub](https://hub.arcgis.com) team uses adlib to build Web Maps, Hub 
 
 To get a feel for how adlib works, check out this [Live Demo](https://arcgis.github.io/ember-arcgis-adlib-service/)!
 
+## API
+```js
+import adlib, { listDependencies } from 'adlib'
+adlib(template, settings) // renders an adlib template
+listDependencies(template) // list all dependecies of an adlib template
+
+```
+
 # General Pattern
 
 ```js
@@ -33,6 +41,13 @@ const result = adlib(template, settings);
 ```
 
 **Note** Adlib does not mutate the template, it returns a new object that contains copies of the template properties with interpolations applied. This allows the template to be used multiple times in succession with different settings hashes.
+
+# List dependencies
+Gets a list of all variables your template depends upon
+```js
+const template = 'Injuries: {{CRASHID}}<br />On Scene: {{ISREPORTONSCENE}}'
+const deps = listDependencies(template); // CRASHID, ISREPORTONSCNE
+```
 
 # Supported Interpolations
 

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -13,6 +13,7 @@ import getWithDefault from './getWithDefault';
 import deepMapValues from './deepMap';
 import {arborist} from './optional-transform/arborist';
 import optionalTransform from './optional-transform/optional';
+const HANDLEBARS = /{{[\w].*?}}/g;
 
 function isString(v) {
   return typeof v === 'string';
@@ -82,9 +83,7 @@ export default function adlib(template, settings, transforms = null) {
     var settingsValue;
     var replaceValue = false;
 
-    var handlebars = /{{[\w].*?}}/g;
-
-    let hbsEntries = templateValue.match(handlebars);
+    let hbsEntries = templateValue.match(HANDLEBARS);
 
     if (hbsEntries && hbsEntries.length) {
       // console.log(`Got a ${hbsEntries.length} handlebar entries...`);
@@ -178,4 +177,27 @@ export default function adlib(template, settings, transforms = null) {
     }
   });
   return arborist(res);
+}
+
+// read a template and spit out unique values
+export function listDependencies(template) {
+  if (typeof template !== 'string') {
+    template = JSON.stringify(template)
+  }
+
+  try {
+    return Array.from(
+      new Set(
+        template.match(HANDLEBARS)
+      )
+    )
+    .map(term => {
+      return term.replace(/^{{/g, '').replace(/}}$/g, '')
+      // Node > 10 and browsers support this w/ a lookahead
+      // won't need to use the replace
+      // /(?<={{)[\w].*?(?=}})/g
+    })
+  } catch (e) {
+    console.error(e)
+  }
 }

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -180,7 +180,7 @@ export default function adlib(template, settings, transforms = null) {
 }
 
 // read a template and spit out unique values
-export function listDependencies(template) {
+adlib.listDependencies = function (template) {
   if (typeof template !== 'string') {
     template = JSON.stringify(template)
   }
@@ -192,7 +192,7 @@ export function listDependencies(template) {
       )
     )
     .map(term => {
-      return term.replace(/^{{/g, '').replace(/}}$/g, '')
+      return term.replace(/^{{/g, '').replace(/}}$/g, '').replace(/:.+$/, '')
       // Node > 10 and browsers support this w/ a lookahead
       // won't need to use the replace
       // /(?<={{)[\w].*?(?=}})/g

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "adlib",
   "version": "2.2.5",
   "description": "Templating for deep JSON object graphs",
-  "main": "dist/adlib.umd.js",
+  "main": "dist/adlib.js",
   "browser": "dist/adlib.min.js",
   "scripts": {
     "start": "npm run build && concurrently \"watch 'npm run build' lib\" \"mocha -w\"",

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -1,6 +1,6 @@
 
 import test from 'tape';
-import adlib, { listDependencies } from '../lib/adlib';
+import adlib from '../lib/adlib';
 
 test('AdLib:: Throws if optional transform passed in', (t)=>{
   let template = {
@@ -81,19 +81,15 @@ test('Adlib::Strings:: allow info-window template to pass through', (t) => {
 
 test('Adlib::listDependencies:: parse dependecies from a string', (t) => {
   const template = 'Injuries: {{CRASHID}}<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'
-  const deps = listDependencies(template);
-  t.equal(deps[0], 'CRASHID');
-  t.equal(deps[1], 'ISREPORTONSCENE');
-  t.equal(deps.length, 2)
+  const deps = new Set(adlib.listDependencies(template));
+  t.deepEqual(deps, new Set('CRASHID', 'ISREPORTONSCENE'));
   t.end();
 })
 
 test('Adlib::listDependencies:: parse dependecies from an object', (t) => {
   const template = {key: 'Injuries: {{CRASHID}}<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'}
-  const deps = listDependencies(template);
-  t.equal(deps[0], 'CRASHID');
-  t.equal(deps[1], 'ISREPORTONSCENE');
-  t.equal(deps.length, 2)
+  const deps = new Set(adlib.listDependencies(template));
+  t.deepEqual(deps, new Set('CRASHID', 'ISREPORTONSCENE'));
   t.end();
 })
 

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -87,9 +87,9 @@ test('Adlib::listDependencies:: parse dependecies from a string', (t) => {
 })
 
 test('Adlib::listDependencies:: parse dependecies from a string with transforms', (t) => {
-  const template = 'Injuries: {{CRASHID}}:toIso<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'
+  const template = 'Injuries: {{CRASHID:toIso}} <br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}} Bar: {{bar.baz.bing}}'
   const deps = new Set(adlib.listDependencies(template));
-  t.deepEqual(deps, new Set('CRASHID', 'ISREPORTONSCENE'));
+  t.deepEqual(deps, new Set('CRASHID', 'ISREPORTONSCENE', 'bar.baz.bing'));
   t.end();
 })
 

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -86,6 +86,13 @@ test('Adlib::listDependencies:: parse dependecies from a string', (t) => {
   t.end();
 })
 
+test('Adlib::listDependencies:: parse dependecies from a string with transforms', (t) => {
+  const template = 'Injuries: {{CRASHID}}:toIso<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'
+  const deps = new Set(adlib.listDependencies(template));
+  t.deepEqual(deps, new Set('CRASHID', 'ISREPORTONSCENE'));
+  t.end();
+})
+
 test('Adlib::listDependencies:: parse dependecies from an object', (t) => {
   const template = {key: 'Injuries: {{CRASHID}}<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'}
   const deps = new Set(adlib.listDependencies(template));

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -1,6 +1,6 @@
 
 import test from 'tape';
-import adlib from '../lib/adlib';
+import adlib, { listDependencies } from '../lib/adlib';
 
 test('AdLib:: Throws if optional transform passed in', (t)=>{
   let template = {
@@ -76,6 +76,24 @@ test('Adlib::Strings:: allow info-window template to pass through', (t) => {
   t.plan(2);
   t.equal(result.value, 'red');
   t.equal(result.description, template.description);
+  t.end();
+})
+
+test('Adlib::listDependencies:: parse dependecies from a string', (t) => {
+  const template = 'Injuries: {{CRASHID}}<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'
+  const deps = listDependencies(template);
+  t.equal(deps[0], 'CRASHID');
+  t.equal(deps[1], 'ISREPORTONSCENE');
+  t.equal(deps.length, 2)
+  t.end();
+})
+
+test('Adlib::listDependencies:: parse dependecies from an object', (t) => {
+  const template = {key: 'Injuries: {{CRASHID}}<br />Fatalities: {{ISREPORTONSCENE}} Foo: {{CRASHID}}'}
+  const deps = listDependencies(template);
+  t.equal(deps[0], 'CRASHID');
+  t.equal(deps[1], 'ISREPORTONSCENE');
+  t.equal(deps.length, 2)
   t.end();
 })
 


### PR DESCRIPTION
Get a list of the unique values a template depends upon.

e.g.
```js
const { listDependencies } = require('adlib')
const template = 'Injuries: {{CRASHID}}<br />Fatalities: {{ISREPORTONSCENE}} Date: {{Date:toIso}}'
const deps = new Set(listDependencies(template));
assert.deepEqual(deps, new Set('CRASHID', 'ISREPORTONSCENE'));
```