### PR TITLE
Handle whitespace in handlebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- changed regex pattern and added `trim` so that handlebars contents can include whitespace that will get ignored
+
 ## 2.3.0
 ### Added
 - adlib.listDependencies function to list all variables in a template

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -13,7 +13,7 @@ import getWithDefault from './getWithDefault';
 import deepMapValues from './deepMap';
 import {arborist} from './optional-transform/arborist';
 import optionalTransform from './optional-transform/optional';
-const HANDLEBARS = /{{[\w].*?}}/g;
+const HANDLEBARS = /{{\s*?[\w].*?}}/g;
 
 function isString(v) {
   return typeof v === 'string';
@@ -91,11 +91,11 @@ export default function adlib(template, settings, transforms = null) {
       // iterate over the entries...
       let values = hbsEntries.map((entry) => {
         // console.info(`Matched ${entry}...`);
-        // strip off the curlies...
-        let path = entry.replace(/{|}/g, '');
+        // strip off the curlies and trim any leading/trailing whitespace...
+        let path = entry.replace(/{|}/g, '').trim();
         // check for || which indicate a hiearchy
         if (path.indexOf('||') > -1) {
-          var paths = path.split('||');
+          var paths = path.split('||').map(path => path.trim());
           let numberOfPaths = paths.length;
           // here we check each option, in order, and return the first with a value in the hash, OR the last
           path = paths.find((pathOption, idx) => {

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -61,6 +61,22 @@ test('Adlib::Strings:: should replace a simple path with a string', (t) => {
   t.end();
 })
 
+test('Adlib::Strings:: should replace a simple path with a string templated with whitespace', (t) => {
+  t.plan(1);
+  let template = {
+    value: '{{ thing.value }}'
+  };
+  let settings = {
+    thing: {
+      value: 'red'
+    }
+  };
+  let result = adlib(template, settings);
+
+  t.equal(result.value, 'red');
+  t.end();
+})
+
 test('Adlib::Strings:: allow info-window template to pass through', (t) => {
 
   let template = {
@@ -613,6 +629,34 @@ test('Adlib::Hierarchies:: templates can specify a value hierarchy and will pref
 
   t.plan(1);
   t.equal(result.timestamp, 'This Item was last modified at 2014-06-03T22:59:36.836Z')
+  t.end();
+})
+
+test('Adlib::Hierarchies:: templates can specify a value hierarchy that includes whitespace', (t) => {
+  t.plan(1);
+  let template = {
+    value: 'The value is {{ thing.value || foo }}'
+  };
+  let settings = {
+    thing: {
+      value: 'red'
+    }
+  };
+  let result = adlib(template, settings);
+
+  t.equal(result.value, 'The value is red');
+  t.end();
+})
+
+test('Adlib::Hierarchies:: templates can properly default when value inclue whitespace', (t) => {
+  t.plan(1);
+  let template = {
+    value: 'The value is {{ thing.notExisting || foo }}'
+  };
+  let settings = {};
+  let result = adlib(template, settings);
+
+  t.equal(result.value, 'The value is foo');
   t.end();
 })
 

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -648,7 +648,7 @@ test('Adlib::Hierarchies:: templates can specify a value hierarchy that includes
   t.end();
 })
 
-test('Adlib::Hierarchies:: templates can properly default when value inclue whitespace', (t) => {
+test('Adlib::Hierarchies:: templates can properly default when value includes whitespace', (t) => {
   t.plan(1);
   let template = {
     value: 'The value is {{ thing.notExisting || foo }}'


### PR DESCRIPTION
Adlib currently not handling whitespace in templates.  For example, consider the template:

    {
      "title": "{{ crashLayer.title || test  }}"
    }

and the companion settings object:

    {
      "crashLayer": {
        "title": "2008 Collisions"
      }
    }

Adlib results in: 
    {
      "title": " test"
    }

when we expect `"title": "2008 Collisions"`.

I was able to fix this by:
1. adding leading whitespace to the for testing handlebars entries
2. Using `.trim()` to ensure the path and/or path fragments have leading and trailing space removed.  This ensures that the code doesn't test something like `" crashLayer" === "crashLayer"`.
