### PR TITLE
Level params and other bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.0
+- perform a deep object clone of `transforms` so that the object passed in is not modified
+- initial value of the transform param is `undefined` instead of `null` so that the `level` arg is properly set to 0 for `optionalTransform`
+- correctly interpolate values that are empty strings
+
 ## 3.0.0
 ### Breaking Changes
 - this library no longer mixes default and named [exports](https://rollupjs.org/guide/en#exporting).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.1.0
+### Fixed
 - perform a deep object clone of `transforms` so that the object passed in is not modified
 - initial value of the transform param is `undefined` instead of `null` so that the `level` arg is properly set to 0 for `optionalTransform`
 - correctly interpolate values that are empty strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.1.0
+## 3.0.1
 ### Fixed
 - perform a deep object clone of `transforms` so that the object passed in is not modified
 - initial value of the transform param is `undefined` instead of `null` so that the `level` arg is properly set to 0 for `optionalTransform`

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -13,6 +13,8 @@ import { getWithDefault } from './getWithDefault';
 import { deepMapValues } from './deepMap';
 import { arborist } from './optional-transform/arborist';
 import { optionalTransform } from './optional-transform/optional';
+// only use this single fn from hub-common
+import { cloneObject } from '@esri/hub-common';
 const HANDLEBARS = /{{\s*?[\w].*?}}/g;
 
 const isString = (v) => typeof v === 'string';
@@ -64,7 +66,7 @@ function _propertyPathExists (propertyPath, target) {
 
 // Combine a Template with Settings
 export function adlib (template, settings, transforms = null) {
-  transforms = transforms || {};
+  transforms = cloneObject(transforms) || {};
   if (transforms.optional) {
     throw new Error('Please do not pass in an `optional` transform; adlib provides that internally.');
   } else {

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -14,7 +14,7 @@ import { deepMapValues } from './deepMap';
 import { arborist } from './optional-transform/arborist';
 import { optionalTransform } from './optional-transform/optional';
 // only use this single fn from hub-common
-import { cloneObject } from '@esri/hub-common';
+import { cloneObject } from './cloneObject';
 const HANDLEBARS = /{{\s*?[\w].*?}}/g;
 
 const isString = (v) => typeof v === 'string';

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -122,10 +122,15 @@ export function adlib (template, settings, transforms = null) {
         let result = {
           key: entry,
           value: path
-        }
+        };
         // if we have a valid object path, value comes from _swap
         if (!isStaticValue) {
-          result.value = _swap(path, settings, transforms) || entry;
+          var swap = _swap(path, settings, transforms);
+          if (swap === '') {
+            result.value = '';
+          } else {
+            result.value = swap || entry;
+          }
         }
         // console.info(`Value: ${JSON.stringify(result)}`);
         return result;
@@ -138,7 +143,7 @@ export function adlib (template, settings, transforms = null) {
           // if the value is a string...
           if (typeof v.value === 'string') {
             // and it's numeric-ish
-            if(!isNaN(v.value)) {
+            if(!isNaN(v.value) && v.value !== '') {
               // and has a . in it...
               if (v.value.indexOf('.') > -1) {
                 // parse as a float...
@@ -162,7 +167,7 @@ export function adlib (template, settings, transforms = null) {
       });
 
       // if we have a value, let's return that...
-      if (settingsValue) {
+      if (settingsValue || settingsValue === '') {
         // console.log(`We found a value so we return it ${settingsValue}`);
         return settingsValue;
       } else {

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -13,7 +13,6 @@ import { getWithDefault } from './getWithDefault';
 import { deepMapValues } from './deepMap';
 import { arborist } from './optional-transform/arborist';
 import { optionalTransform } from './optional-transform/optional';
-// only use this single fn from hub-common
 import { cloneObject } from './cloneObject';
 const HANDLEBARS = /{{\s*?[\w].*?}}/g;
 

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -29,7 +29,7 @@ function _swap(parameter, settings, transforms) {
     let key = transformCheck[0];
     let fn = transformCheck[1];
     // we default to using the value...
-    let param = null;
+    let param;
     if (transformCheck[2]){
       param = transformCheck[2];
     }

--- a/lib/cloneObject.js
+++ b/lib/cloneObject.js
@@ -1,0 +1,43 @@
+/*    Copyright (c) 2017-2019 Esri Inc.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/**
+ * ```js
+ * import { cloneObject } from "./cloneObject";
+ * const original = { foo: "bar" }
+ * const copy = cloneObject(original)
+ * copy.foo // "bar"
+ * copy === original // false
+ * ```
+ * Make a deep clone, including arrays. Does not handle functions!
+ *
+ * Copied from @esri/hub-common to avoid bringing along that package's
+ * dependencies, @esri/hub-common should be made a dependency if more
+ * functions are needed from it in the future
+ */
+export const cloneObject = function (obj) {
+  let clone = {};
+  // first check array
+  if (Array.isArray(obj)) {
+    clone = obj.map(cloneObject);
+  } else if (typeof obj === "object") {
+    for (const i in obj) {
+      if (obj[i] != null && typeof obj[i] === "object") {
+        clone[i] = cloneObject(obj[i]);
+      } else {
+        clone[i] = obj[i];
+      }
+    }
+  } else {
+    clone = obj;
+  }
+  return clone;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adlib",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "Templating for deep JSON object graphs",
   "main": "dist/adlib.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adlib",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Templating for deep JSON object graphs",
   "main": "dist/adlib.js",
   "module": "lib/index.js",
@@ -71,6 +71,7 @@
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-react": "^7.9.1",
     "eslint-plugin-standard": "^3.1.0",
+    "@esri/hub-common": "^2.4.0",
     "mocha": "^5.2.0",
     "rollup": "^1.0.1",
     "rollup-plugin-babel": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-react": "^7.9.1",
     "eslint-plugin-standard": "^3.1.0",
-    "@esri/hub-common": "^2.4.0",
     "mocha": "^5.2.0",
     "rollup": "^1.0.1",
     "rollup-plugin-babel": "^4.2.0",

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -30,6 +30,22 @@ test('AdLib:: Does not throw if other transform passed in', (t)=>{
   t.doesNotThrow(() => adlib(template, {}, transforms));
 });
 
+test('AdLib:: Does not modify transform object', (t)=>{
+  let template = {
+    foo: 'bar',
+    baz: ['one', 'two']
+  };
+  let transforms = {
+    someOther: function (k,v,s, p) {
+      return v;
+    }
+  };
+  t.plan(1);
+  adlib(template, {}, transforms);
+  t.notOk(transforms.optional);
+  t.end();
+});
+
 test('Adlib::Strings:: should return a deep copy of the template', (t) => {
   let template = {
     foo: 'bar',

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -160,6 +160,21 @@ test('Adlib::Strings:: should allow triple curlies and leave the outer set', (t)
   t.end();
 })
 
+test('Adlib::Strings:: should replace a path with an empty string', (t) => {
+  t.plan(1);
+  let template = {
+    value: '{{thing.value}}'
+  };
+  let settings = {
+    thing: {
+      value: ''
+    }
+  };
+  let result = adlib(template, settings);
+
+  t.equal(result.value, '');
+  t.end();
+})
 
 test('Adlib::Strings:: should replace multiple instances within a larger string', (t) => {
   t.plan(1);

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -569,7 +569,8 @@ test('Adlib::Optional:: missing optional array entry is removed', (t) => {
       {
         color: '{{s.color}}',
         props: '{{j.props:optional:1}}'
-      }
+      },
+      '{{j.props:optional}}'
     ]
   };
   let settings = {


### PR DESCRIPTION
- perform a deep object clone of `transforms` so that the object passed in is not modified
- initial value of the transform param is `undefined` instead of `null` so that the `level` arg is properly set to 0 for `optionalTransform`
- correctly interpolate values that are empty strings [36](https://github.com/Esri/adlib/issues/36)