### PR TITLE
fix(): leading zeroes of string accidentally removed

### DIFF
--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -31,10 +31,10 @@ function _swap(parameter, settings, transforms) {
     let fn = transformCheck[1];
     // we default to using the value...
     let param;
-    if (transformCheck[2]){
+    if (transformCheck[2]) {
       param = transformCheck[2];
     }
-    if(transforms && transforms[fn] && typeof transforms[fn] === 'function') {
+    if (transforms && transforms[fn] && typeof transforms[fn] === 'function') {
       // get the value from the param
       value = getWithDefault(settings, key);
       // transform it...
@@ -52,7 +52,7 @@ function _swap(parameter, settings, transforms) {
 /**
  * Does a propertyPath exist on a target
  */
-function _propertyPathExists (propertyPath, target) {
+function _propertyPathExists(propertyPath, target) {
   // remove any transforms
   let cleanPath = propertyPath.split(':')[0];
   let value = getWithDefault(target, cleanPath, null);
@@ -66,12 +66,12 @@ function _propertyPathExists (propertyPath, target) {
 /**
  * Is the value considered valid
  */
-function _isValue (val) {
+function _isValue(val) {
   return val || val === '' || val === 0;
 }
 
 // Combine a Template with Settings
-export function adlib (template, settings, transforms = null) {
+export function adlib(template, settings, transforms = null) {
   transforms = cloneObject(transforms) || {};
   if (transforms.optional) {
     throw new Error('Please do not pass in an `optional` transform; adlib provides that internally.');
@@ -79,7 +79,7 @@ export function adlib (template, settings, transforms = null) {
     transforms.optional = optionalTransform;
   }
 
-  let res = deepMapValues(template, function(templateValue, templatePath){
+  let res = deepMapValues(template, function (templateValue, templatePath) {
     // Only string templates
     if (!isString(templateValue)) {
       return templateValue;
@@ -144,15 +144,18 @@ export function adlib (template, settings, transforms = null) {
           // console.log(`template matches key, returning ${v.value}`);
           // if the value is a string...
           if (typeof v.value === 'string') {
-            // and it's numeric-ish
-            if(!isNaN(v.value) && v.value !== '') {
+            // and it's numeric-ish and does not have leading 0s
+            if (!isNaN(v.value) && v.value !== '') {
               // and has a . in it...
               if (v.value.indexOf('.') > -1) {
                 // parse as a float...
                 v.value = parseFloat(v.value);
+
               } else {
-                // parse as an int
-                v.value = parseInt(v.value);
+                // if no leading 0s, parse as an int
+                if (v.value[0] !== '0'){ 
+                  v.value = parseInt(v.value);
+                }
               }
             }
           }
@@ -187,7 +190,7 @@ export function adlib (template, settings, transforms = null) {
 }
 
 // read a template and spit out unique values
-export function listDependencies (template) {
+export function listDependencies(template) {
   if (typeof template !== 'string') {
     template = JSON.stringify(template)
   }
@@ -198,12 +201,12 @@ export function listDependencies (template) {
         template.match(HANDLEBARS)
       )
     )
-    .map(term => {
-      return term.replace(/^{{/g, '').replace(/}}$/g, '').replace(/:.+$/, '')
-      // Node > 10 and browsers support this w/ a lookahead
-      // won't need to use the replace
-      // /(?<={{)[\w].*?(?=}})/g
-    })
+      .map(term => {
+        return term.replace(/^{{/g, '').replace(/}}$/g, '').replace(/:.+$/, '')
+        // Node > 10 and browsers support this w/ a lookahead
+        // won't need to use the replace
+        // /(?<={{)[\w].*?(?=}})/g
+      })
   } catch (e) {
     console.error(e)
   }

--- a/test/adlib.spec.js
+++ b/test/adlib.spec.js
@@ -247,7 +247,7 @@ describe('adlib ::', () => {
   describe('arrays ::', () => {
     it('should replace tokens within an array with strings', () => {
       let template = {
-        values: ['{{s.animal}}', 'fuzzy','{{s.color}}']
+        values: ['{{s.animal}}', 'fuzzy', '{{s.color}}']
       };
       let settings = {
         s: {
@@ -279,7 +279,7 @@ describe('adlib ::', () => {
 
     it('should replace tokens with an array', () => {
       let template = {
-        values:'{{s.animals}}'
+        values: '{{s.animals}}'
       };
       let settings = {
         s: {
@@ -295,7 +295,7 @@ describe('adlib ::', () => {
     });
     it('should replace tokens with an array and run transforms', () => {
       let template = {
-        values:'{{s.animals:upcaseArr}}'
+        values: '{{s.animals:upcaseArr}}'
       };
       let settings = {
         s: {
@@ -305,8 +305,8 @@ describe('adlib ::', () => {
         }
       };
       let transforms = {
-        upcaseArr (key, val, settings) {
-          return val.map((v) =>{
+        upcaseArr(key, val, settings) {
+          return val.map((v) => {
             return v.toUpperCase();
           })
         }
@@ -318,7 +318,7 @@ describe('adlib ::', () => {
     });
     it('should run passed in transforms', () => {
       let template = {
-        value:'{{s.animal.type:upcase}}'
+        value: '{{s.animal.type:upcase}}'
       };
       let settings = {
         s: {
@@ -329,7 +329,7 @@ describe('adlib ::', () => {
         }
       };
       let transforms = {
-        upcase (key, val, settings) {
+        upcase(key, val, settings) {
           return val.toUpperCase() + settings.s.color;
         }
       };
@@ -340,7 +340,7 @@ describe('adlib ::', () => {
 
     it('should run transform even if value is undefined', () => {
       let template = {
-        value:'{{s.animal.type:upcase}}'
+        value: '{{s.animal.type:upcase}}'
       };
       let settings = {
         s: {
@@ -348,7 +348,7 @@ describe('adlib ::', () => {
         }
       };
       let transforms = {
-        upcase (key, val, settings) {
+        upcase(key, val, settings) {
           return key.toUpperCase();
         }
       };
@@ -359,7 +359,7 @@ describe('adlib ::', () => {
 
     it('transform has access to settings hash', () => {
       let template = {
-        value:'{{s.animal.type:upcase}}'
+        value: '{{s.animal.type:upcase}}'
       };
       let settings = {
         s: {
@@ -367,13 +367,30 @@ describe('adlib ::', () => {
         }
       };
       let transforms = {
-        upcase (key, val, settings) {
+        upcase(key, val, settings) {
           return `${key.toUpperCase()} is ${settings.s.color}`;
         }
       };
       let result = adlib.adlib(template, settings, transforms);
       expect(result.value).not.to.be.undefined;
       expect(result.value).to.equal('S.ANIMAL.TYPE is brown');
-    })
+    });
+
+    it('adlib::handles a leading 0 effectively', (t) => {
+      const template = {
+        subdomain: "{{solution.subdomain}}"
+      };
+
+      const settings = {
+        solution: {
+          subdomain: "0000332",
+        },
+      };
+
+      const transforms = {};
+      let result = adlib(template, settings, transforms);
+      expect(result.subdomain).to.equal('0000332');
+    });
+
   })
 })

--- a/test/adlib.spec.js
+++ b/test/adlib.spec.js
@@ -376,7 +376,7 @@ describe('adlib ::', () => {
       expect(result.value).to.equal('S.ANIMAL.TYPE is brown');
     });
 
-    it('adlib::handles a leading 0 effectively', (t) => {
+    it('adlib handles a leading 0 effectively', () => {
       const template = {
         subdomain: "{{solution.subdomain}}"
       };
@@ -392,5 +392,36 @@ describe('adlib ::', () => {
       expect(result.subdomain).to.equal('0000332');
     });
 
+    it('adlib handles floats correctly', () => {
+      const template = {
+        float: "{{solution.float}}"
+      };
+
+      const settings = {
+        solution: {
+          float: '0.01',
+        }
+      };
+
+      const transforms = {};
+      let result = adlib(template, settings, transforms);
+      expect(result.float).to.equal(0.01);
+    });
+
+    it('adlib handles integers correctly', () => {
+      const template = {
+        integer: "{{solution.integer}}"
+      };
+
+      const settings = {
+        solution: {
+          integer: '7',
+        }
+      };
+
+      const transforms = {};
+      let result = adlib(template, settings, transforms);
+      expect(result.integer).to.equal(7);
+    });
   })
 })

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -948,3 +948,40 @@ test('adlib::handles a leading 0 effectively', (t) => {
   t.end();
 });
 
+
+test('adlib::handles floats correctly', (t) => {
+  const template = {
+    float: "{{solution.float}}"
+  };
+
+  const settings = {
+    solution: {
+      float: '0.01',
+    }
+  };
+
+  const transforms = {};
+  let result = adlib(template, settings, transforms);
+  t.plan(1);
+  t.equal(result.float, 0.01);
+  t.end();
+});
+
+test('adlib::handles integers correctly', (t) => {
+  const template = {
+    integer: "{{solution.integer}}"
+  };
+
+  const settings = {
+    solution: {
+      integer: '7',
+    }
+  };
+
+  const transforms = {};
+  let result = adlib(template, settings, transforms);
+  t.plan(2);
+  t.equal(result.integer, 7);
+  t.end();
+});
+

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -928,5 +928,24 @@ test('Adlib::Hierarchies:: missing value with defaults does not stop processing'
   t.plan(1);
   t.equal(result.msg, 'myOrg<br />https://www.arcgis.com/sharing/rest/content/items/28989a5ecc2d4b2fbf62ac0f5075b7ff/data<br />myOrg');
   t.end();
-})
+});
+
+test('adlib::handles a leading 0 effectively', (t) => {
+  const template = {
+    subdomain: "{{solution.subdomain}}"
+  };
+
+  const settings = {
+    solution: {
+      subdomain: "0000332",
+    },
+  };
+
+  const transforms = {};
+  let result = adlib(template, settings, transforms);
+  console.log('result: ', result);
+  t.plan(1);
+  t.equal(result.subdomain, '0000332');
+  t.end();
+});
 

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -943,7 +943,6 @@ test('adlib::handles a leading 0 effectively', (t) => {
 
   const transforms = {};
   let result = adlib(template, settings, transforms);
-  console.log('result: ', result);
   t.plan(1);
   t.equal(result.subdomain, '0000332');
   t.end();

--- a/test/adlib.tape.js
+++ b/test/adlib.tape.js
@@ -980,7 +980,7 @@ test('adlib::handles integers correctly', (t) => {
 
   const transforms = {};
   let result = adlib(template, settings, transforms);
-  t.plan(2);
+  t.plan(1);
   t.equal(result.integer, 7);
   t.end();
 });


### PR DESCRIPTION
## Description
This PR addresses a bug in the `adlib` function where, if a string is all-numeric and has leading 0s, then the leading 0s are incorrectly removed from the string. This addresses [issue 4813](https://zentopia.esri.com/workspaces/polaris-sprint-board-614a18b38a61a3001196c48d/issues/dc/hub/4813) where enterprise sites that start with leading 0s cannot be routed correctly. 

## Change
After having been determined that the string can be converted to an integer, there is now a check to see if the string has leading 0s. If it has leading 0s, the string will remain as a string; otherwise, it will be converted to an integer. 

This also adds a test to ensure that a value with a leading 0 will remain the same after running through the function. 